### PR TITLE
Repair broken composer config caused by previous merge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "symfony/web-link": "7.2.*",
         "symfony/webpack-encore-bundle": "*",
         "symfony/yaml": "7.2.*",
-        "symfonycasts/verify-email-bundle": "^1.17",
         "twig/extra-bundle": "^2.12|^3.0",
         "twig/twig": "^2.12|^3.0"
     },

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -12,5 +12,4 @@ return [
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
-    SymfonyCasts\Bundle\VerifyEmail\SymfonyCastsVerifyEmailBundle::class => ['all' => true],
 ];

--- a/symfony.lock
+++ b/symfony.lock
@@ -287,6 +287,7 @@
             "package.json",
             "webpack.config.js"
         ]
+    },
     "symfonycasts/verify-email-bundle": {
         "version": "v1.17.2"
     },


### PR DESCRIPTION
verify-email-bundle was added to composer.json but not lock file, and symfony.lock had a syntax error